### PR TITLE
Increase email max length to 254

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-RDM-3853.xml
+++ b/src/main/resources/db/changelog/db.changelog-RDM-3853.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="3" author="vlaurin">
+        <modifyDataType tableName="user_profile"
+                        columnName="id"
+                        newDataType="varchar(254)"
+        />
+        <modifyDataType tableName="user_profile_jurisdiction"
+                        columnName="user_profile_id"
+                        newDataType="varchar(254)"
+        />
+    </changeSet>
+</databaseChangeLog>
+

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -6,4 +6,5 @@
     <include file="db/changelog/db.changelog-0.0.1.xml"/>
     <include file="db/changelog/db.changelog-0.0.2.xml"/>
     <include file="db/changelog/db.changelog-RDM-2761-UserProfileAuditTable.xml"/>
+    <include file="db/changelog/db.changelog-RDM-3853.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

According to RFC http://www.rfc-editor.org/errata_search.php?rfc=3696&eid=1690 email addresses can be up to 254 characters long. There's no justification for the current 64 characters limit.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```