### PR TITLE
RDM-2268: Reduce default capacity

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,2 +1,3 @@
 vault_section = "preprod"
 use_uk_db = "true"
+capacity = "2"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,0 +1,1 @@
+capacity = "2"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,2 +1,3 @@
 vault_section = "prod"
 use_uk_db = "true"
+capacity = "2"

--- a/infrastructure/sprod.tfvars
+++ b/infrastructure/sprod.tfvars
@@ -1,0 +1,1 @@
+capacity = "2"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -19,6 +19,10 @@ variable "subscription" {
   type = "string"
 }
 
+variable "capacity" {
+  default = "1"
+}
+
 variable "ilbIp"{}
 
 variable "tenant_id" {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-2268

### Change description ###

Reduce number of instances from 2 to 1 for all envs apart from `demo`, `prod`, `aat` and `sprod`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```