### PR TITLE
Deps: Spring Boot to 2.0.3 for CVE-2018-1258

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 plugins {
     id 'application'
     id 'io.spring.dependency-management' version '1.0.5.RELEASE'
-    id 'org.springframework.boot' version '1.5.13.RELEASE'
+    id 'org.springframework.boot' version '2.0.3.RELEASE'
     id 'org.owasp.dependencycheck' version '3.2.1'
     id 'se.patrikerdes.use-latest-versions' version '0.2.3'
     id 'com.github.ben-manes.versions' version '0.17.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.5.13.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.0.3.RELEASE")
     }
     dependencies {
         classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.2"

--- a/build.gradle
+++ b/build.gradle
@@ -157,6 +157,7 @@ dependencies {
     testCompile group: 'com.opentable.components', name: 'otj-pg-embedded', version: '0.12.0'
     testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.18.0'
     testCompile group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: '1.2.4.RELEASE'
+    runtime("org.springframework.boot:spring-boot-properties-migrator")
 }
 // end::dependencies[]
 

--- a/src/main/java/uk/gov/hmcts/ccd/hikari/HikariConfigurationPropertiesReportEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/hikari/HikariConfigurationPropertiesReportEndpoint.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.ccd.hikari;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zaxxer.hikari.HikariDataSource;
-import org.springframework.boot.actuate.endpoint.ConfigurationPropertiesReportEndpoint;
+import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint;
 import org.springframework.stereotype.Component;
 
 // needed to fix  "error" : "Cannot serialize 'spring.datasource.hikari'" in actuator /configprops endpoint


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2464




Increase Spring Boot dep to 2.0.2.RELEASE+ to address CVE-2018-1258



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```