### PR TITLE
[PREVIEW] RDM-2934: Use exact match on ID for retrieving User Profiles

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepository.java
@@ -80,7 +80,7 @@ public class UserProfileRepository {
     }
 
     private UserProfileEntity findEntityById(String id) {
-        return em.find(UserProfileEntity.class, id.toLowerCase());
+        return em.find(UserProfileEntity.class, id);
     }
 
     public List<UserProfile> findAll(String jurisdictionId) {

--- a/src/test/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepositoryTest.java
@@ -65,6 +65,9 @@ public class UserProfileRepositoryTest {
         userProfileWithMultipleJurisdictions =
             createUserProfile("user4@hmcts.net", jurisdiction.getId(), "TEST5", "TEST6");
         saveUserProfileClearAndFlushSession(userProfileWithMultipleJurisdictions);
+        final UserProfile mixedCaseUserProfile =
+            createUserProfile("User@HMCTS.net", jurisdiction.getId());
+        saveUserProfileClearAndFlushSession(mixedCaseUserProfile);
     }
 
     @Test
@@ -115,9 +118,17 @@ public class UserProfileRepositoryTest {
     }
 
     @Test
+    public void findUserProfileByIdCaseSensitive() {
+        final UserProfile userProfile = classUnderTest.findById("User@HMCTS.net");
+        assertEquals("User@HMCTS.net", userProfile.getId());
+        assertEquals("TEST", userProfile.getWorkBasketDefaultJurisdiction());
+        assertNull(userProfile.getJurisdictions());
+    }
+
+    @Test
     public void findAllUserProfiles() {
         final List<UserProfile> userProfiles = classUnderTest.findAll();
-        assertEquals(3, userProfiles.size());
+        assertEquals(4, userProfiles.size());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/userprofile/UserProfileEndpointIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/userprofile/UserProfileEndpointIT.java
@@ -40,8 +40,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class UserProfileEndpointIT extends BaseTest {
 
     private static final String CREATE_USER_PROFILE = "/user-profile/users";
-    private static final String FIND_JURISDICTION_FOR_USER_1 = "/user-profile/users?uid=USER1";
-    private static final String FIND_JURISDICTION_FOR_USER_2 = "/user-profile/users?uid=User2";
+    private static final String FIND_JURISDICTION_FOR_USER_1 = "/user-profile/users?uid=user1";
+    private static final String FIND_JURISDICTION_FOR_USER_2 = "/user-profile/users?uid=user2";
     private static final String USER_PROFILE_USERS_DEFAULTS = "/users";
     private static final String GET_ALL_USER_PROFILES_FOR_JURISDICTION = "/users?jurisdiction=TEST1";
     private static final String GET_ALL_USER_PROFILES = "/users";
@@ -352,7 +352,7 @@ public class UserProfileEndpointIT extends BaseTest {
         final MvcResult mvcResult = mockMvc.perform(get(FIND_JURISDICTION_FOR_USER_1)).andReturn();
 
         assertEquals("Unexpected response status", 400, mvcResult.getResponse().getStatus());
-        assertEquals("Unexpected response message", "No user exists with the Id 'USER1'",
+        assertEquals("Unexpected response message", "No user exists with the Id '" + USER_ID_1 + "'",
             mvcResult.getResponse().getContentAsString());
     }
 


### PR DESCRIPTION
Ensure that the user ID is used as is, and is not converted to lowercase.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-2934.

### Change description ###
Pass the user ID as is, when searching for a User Profile entity. Although not normally expected, this will allow User Profiles that have been created with a mixed-case email address to be accessed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
