### PR TITLE
Suppress CVE-2018-14335 for h2database

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -24,6 +24,10 @@
         <cve>CVE-2018-10054</cve>
     </suppress>
     <suppress>
+        <notes>h2database is pulled in by liquibase, it is not used in development or production</notes>
+        <cve>CVE-2018-14335</cve>
+    </suppress>
+    <suppress>
         <notes>We do not use: Spring Framework 5.0.5.RELEASE + Spring Security (any version), see https://pivotal.io/security/cve-2018-1258</notes>
         <cve>CVE-2018-1258</cve>
     </suppress>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-3002



This is pulled in by liquibase for JDBC driver support.  We don't use h2
in development or production.




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```