### PR TITLE
Bump checkstyle version to 8.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ wrapper {
 checkstyle {
     maxWarnings = 0
 
-    toolVersion = '8.3'
+    toolVersion = '8.12'
     // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
     configDir = new File(rootDir, 'config/checkstyle')
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2605




This app has no checkstyle issues at all.  So we're just bumping the
checkstyle tester.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```