### PR TITLE
RDM-4369: Support reserved characters in userId email address

### DIFF
--- a/src/main/java/uk/gov/hmcts/ccd/endpoint/userprofile/UserProfileEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/ccd/endpoint/userprofile/UserProfileEndpoint.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriUtils;
 import uk.gov.hmcts.ccd.AppInsights;
 import uk.gov.hmcts.ccd.domain.model.UserProfile;
 import uk.gov.hmcts.ccd.domain.service.CreateUserProfileOperation;
@@ -81,7 +82,8 @@ public class UserProfileEndpoint {
                                       @RequestHeader(value = "actionedBy", defaultValue = "<UNKNOWN>")
                                       final String actionedBy) {
         Instant start = Instant.now();
-        UserProfile userProfile = findUserProfileOperation.execute(uid, actionedBy);
+        String decodedUid = UriUtils.decode(uid, "UTF-8");
+        UserProfile userProfile = findUserProfileOperation.execute(decodedUid, actionedBy);
         final Duration between = Duration.between(start, Instant.now());
         appInsights.trackRequest(between, true);
         return userProfile;

--- a/src/test/java/uk/gov/hmcts/ccd/endpoint/userprofile/UserProfileEndpointIT.java
+++ b/src/test/java/uk/gov/hmcts/ccd/endpoint/userprofile/UserProfileEndpointIT.java
@@ -41,7 +41,7 @@ public class UserProfileEndpointIT extends BaseTest {
 
     private static final String CREATE_USER_PROFILE = "/user-profile/users";
     private static final String FIND_JURISDICTION_FOR_USER_1 = "/user-profile/users?uid=user1";
-    private static final String FIND_JURISDICTION_FOR_USER_2 = "/user-profile/users?uid=user2";
+    private static final String FIND_JURISDICTION_FOR_USER_2 = "/user-profile/users?uid=user2%2Ba%40example.com";
     private static final String USER_PROFILE_USERS_DEFAULTS = "/users";
     private static final String GET_ALL_USER_PROFILES_FOR_JURISDICTION = "/users?jurisdiction=TEST1";
     private static final String GET_ALL_USER_PROFILES = "/users";
@@ -52,7 +52,7 @@ public class UserProfileEndpointIT extends BaseTest {
     private static final String DELETE_SOLE_JURISDICTION = "/users?uid=user5&jid=TEST2";
 
     private static final String USER_ID_1 = "user1";
-    private static final String USER_ID_2 = "user2";
+    private static final String USER_ID_2 = "user2+a@example.com";
     private static final String USER_ID_3 = "user3";
     private static final String JURISDICTION_ID_1 = "TEST1";
     private static final String JURISDICTION_ID_2 = "TEST2";
@@ -366,7 +366,7 @@ public class UserProfileEndpointIT extends BaseTest {
     @Sql(executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD, // checkstyle line break
         scripts = {"classpath:sql/init_db.sql", "classpath:sql/create_user_profile.sql"})
     public void noJurisdictionsForUserProfile() throws Exception {
-        // Given - a User Profile (id = user2) with 0 Jurisdictions
+        // Given - a User Profile (id = user2+a@example.com) with 0 Jurisdictions
         int rows = JdbcTestUtils.countRowsInTableWhere(template,
                 "user_profile_jurisdiction",
                 "user_profile_id = '" + USER_ID_2 + "'");
@@ -550,7 +550,7 @@ public class UserProfileEndpointIT extends BaseTest {
             auditRowCreate4 =
             JdbcTestUtils.countRowsInTableWhere(template,
                                                 "user_profile_audit",
-                                                "action = 'CREATE' and user_profile_id = 'user2'");
+                                                "action = 'CREATE' and user_profile_id = 'user2+a@example.com'");
         assertEquals("Unexpected number of audit roles", 0, auditRowCreate4);
 
     }

--- a/src/test/resources/sql/create_user_profile.sql
+++ b/src/test/resources/sql/create_user_profile.sql
@@ -8,7 +8,7 @@ VALUES ('user1', 'TEST2', 'case', 'state');
 INSERT INTO user_profile(id, work_basket_default_jurisdiction, work_basket_default_case_type, work_basket_default_state)
 VALUES ('user5', 'TEST2', 'case', 'state');
 
-INSERT INTO user_profile(id) VALUES ('user2');
+INSERT INTO user_profile(id) VALUES ('user2+a@example.com');
 INSERT INTO user_profile(id) VALUES ('user4');
 
 INSERT INTO user_profile_jurisdiction(user_profile_id, jurisdiction_id) VALUES ('user1', 'TEST1');


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4369.

### Change description ###
Ensure the email address passed in the `uid` query parameter is decoded before use; requests from ccd-data-store-api will be sending this encoded.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
