### PR TITLE
Bump jackson-databind to v2.9.9 for CVE-2019-12086

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,9 @@ dependencies {
     compile 'uk.gov.hmcts.reform:properties-volume-spring-boot-starter:0.0.4'
     compile 'uk.gov.hmcts.reform:health-spring-boot-starter:0.0.3'
 
+    // CVE-2019-12086 - force update of jackson-databind - remove when dependencies move off <2.9.9
+    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
+
     aatCompile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '2.0.0'
     testCompile "org.junit.jupiter:junit-jupiter-api"
     testRuntime "org.junit.jupiter:junit-jupiter-engine"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -115,4 +115,12 @@
         <cve>CVE-2014-3488</cve>
         <cve>CVE-2015-2156</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+            file name: jackson-databind-2.9.8.jar
+            We've upgraded to jackson-databind 2.9.9 but the dependecy check keeps flagging it, thus mark as false positive.
+        ]]></notes>
+        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:2\.9\.8$</gav>
+        <cve>CVE-2019-12086</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-4823


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```