### PR TITLE
RDM-5730-Fix as per deprecated changes in cnp_jenkins lib- ref:https://gi…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -46,7 +46,7 @@ withPipeline(type, product, component) {
         env.CCD_DS_SERVICE_NAME = "ccd_data"
     }
 
-    enableDbMigration()
+    enableDbMigration('ccd')
     enableDockerBuild()
 
     overrideVaultEnvironments(vaultOverrides)

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -85,31 +85,31 @@ module "user-profile-db" {
 ////////////////////////////////
 
 resource "azurerm_key_vault_secret" "POSTGRES-USER" {
-  name = "${local.app_full_name}-POSTGRES-USER"
+  name = "${var.component}-POSTGRES-USER"
   value = "${module.user-profile-db.user_name}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES-PASS" {
-  name = "${local.app_full_name}-POSTGRES-PASS"
+  name = "${var.component}-POSTGRES-PASS"
   value = "${module.user-profile-db.postgresql_password}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_HOST" {
-  name = "${local.app_full_name}-POSTGRES-HOST"
+  name = "${var.component}-POSTGRES-HOST"
   value = "${module.user-profile-db.host_name}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_PORT" {
-  name = "${local.app_full_name}-POSTGRES-PORT"
+  name = "${var.component}-POSTGRES-PORT"
   value = "${module.user-profile-db.postgresql_listen_port}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }
 
 resource "azurerm_key_vault_secret" "POSTGRES_DATABASE" {
-  name = "${local.app_full_name}-POSTGRES-DATABASE"
+  name = "${var.component}-POSTGRES-DATABASE"
   value = "${module.user-profile-db.postgresql_database}"
   key_vault_id = "${data.azurerm_key_vault.ccd_shared_key_vault.id}"
 }

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -1,10 +1,3 @@
-output "microserviceName" {
-  value = "${local.app_full_name}"
-}
-
-output "vaultName" {
-  value = "${local.vaultName}"
-}
 output "s2s_url" {
   value = "${local.s2s_url}"
 }

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -3,4 +3,4 @@ spring:
     propertiesvolume:
       paths: /mnt/secrets/ccd
       aliases:
-        ccd.ccd-user-profile-api-POSTGRES-PASS: USER_PROFILE_DB_PASSWORD
+        ccd.user-profile-api-POSTGRES-PASS: USER_PROFILE_DB_PASSWORD


### PR DESCRIPTION
### Change description ###

hmcts/cnp-jenkins-library#533 changed to using the component for looking up the vault prefix, it was expected that all teams were doing this, inside of your own vault there is no need to prefix the secret with the product.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```