### PR TITLE
Bump java base chart

### DIFF
--- a/charts/ccd-user-profile-api/Chart.yaml
+++ b/charts/ccd-user-profile-api/Chart.yaml
@@ -2,7 +2,7 @@ description: CCD User profile
 name: ccd-user-profile-api
 apiVersion: v1
 home: https://github.com/hmcts/ccd-user-profile-api
-version: 1.2.0
+version: 1.2.1
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-user-profile-api/requirements.yaml
+++ b/charts/ccd-user-profile-api/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.9.1
+    version: ~2.15.0
     repository: '@hmctspublic'


### PR DESCRIPTION
bulk-scanning is currently blocked because of a clash in the tpl in an old version of chart-java, this was fixed in ~2.10