### PR TITLE
RDM-7709 and RDM-7707

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencyCheck {
     suppressionFile = 'dependency-check-suppressions.xml'
 }
 
-// tag::repositories[]
+ // tag::repositories[]
 repositories {
     mavenLocal()
     jcenter()

--- a/src/main/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepository.java
@@ -257,12 +257,8 @@ public class UserProfileRepository {
                                                                               actionedBy,
                                                                               audit.getWorkBasketDefaultJurisdiction());
             }
-            return UserProfileMapper.entityToModel(userProfileEntity);
-        } else {
-            throw new BadRequestException("User is already a member of the "
-                                          + userProfile.getWorkBasketDefaultJurisdiction()
-                                          + " jurisdiction");
         }
+        return UserProfileMapper.entityToModel(userProfileEntity);
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepository.java
+++ b/src/main/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepository.java
@@ -222,7 +222,7 @@ public class UserProfileRepository {
      *     for audit trail
      * @return The updated UserProfile
      * @throws BadRequestException
-     *     If there is no such user, or if the user already belongs to the given Jurisdiction
+     *       If there is no such user
      */
     public UserProfile updateUserProfileOnCreate(final UserProfile userProfile, final String actionedBy) {
 

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/SaveUserProfileOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/SaveUserProfileOperation.java
@@ -47,8 +47,7 @@ public class SaveUserProfileOperation {
         if (foundUserProfile == null) {
             return createUserProfileOperation.execute(userProfile, actionedBy);
         } else {
-            // Attempt to update the user profile (UserProfileRepository will throw an exception if the user is being
-            // added to a Jurisdiction they already belong to)
+            // Attempt to update the user profile
             return userProfileRepository.updateUserProfileOnCreate(userProfile, actionedBy);
         }
     }

--- a/src/main/java/uk/gov/hmcts/ccd/domain/service/UserProfileOperation.java
+++ b/src/main/java/uk/gov/hmcts/ccd/domain/service/UserProfileOperation.java
@@ -93,8 +93,12 @@ public class UserProfileOperation {
         final Jurisdiction jurisdiction = new Jurisdiction();
         jurisdiction.setId(userProfile.getWorkBasketDefaultJurisdiction());
 
-        // link user profile and jurisdiction
-        userProfile.addJurisdiction(jurisdiction);
+        if (userProfile.getJurisdictions() == null
+            || userProfile.getJurisdictions().stream().map(Jurisdiction::getId)
+            .noneMatch(jurisdiction.getId()::equals)) {
+            // link user profile and jurisdiction
+            userProfile.addJurisdiction(jurisdiction);
+        }
 
         return userProfile;
     }

--- a/src/test/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/ccd/data/userprofile/UserProfileRepositoryTest.java
@@ -274,11 +274,18 @@ public class UserProfileRepositoryTest {
         final UserProfile userProfile = createUserProfile("user@hmcts.net", "TEST2");
         userProfile.setWorkBasketDefaultCaseType("Test case");
         userProfile.setWorkBasketDefaultState("Create case");
-        exceptionRule.expect(BadRequestException.class);
-        exceptionRule.expectMessage("User is already a member of the "
-            + userProfile.getWorkBasketDefaultJurisdiction() + " jurisdiction");
-        classUnderTest.updateUserProfileOnCreate(userProfile, ACTIONED_BY_EMAIL);
-        assertEquals(0, countUserProfitAudits());
+        final UserProfile retrievedUserProfile = classUnderTest.updateUserProfileOnCreate(userProfile,
+            ACTIONED_BY_EMAIL);
+
+        assertEquals(userProfile.getId(), retrievedUserProfile.getId());
+        assertEquals("TEST2", retrievedUserProfile.getWorkBasketDefaultJurisdiction());
+        assertEquals("Test case", retrievedUserProfile.getWorkBasketDefaultCaseType());
+        assertEquals("Create case", retrievedUserProfile.getWorkBasketDefaultState());
+        assertEquals(1, retrievedUserProfile.getJurisdictions().size());
+        assertEquals("TEST2", retrievedUserProfile.getJurisdictions().get(0).getId());
+
+        final List<UserProfileAuditEntity> audits = findUserProfitAudits("user@hmcts.net");
+        assertThat(audits.size(), is(0));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-7709
https://tools.hmcts.net/jira/browse/RDM-7707


### Change description ###

RDM-7709 : not returning error now when user profile is already a member of the said jurisdiction.

RDM-7707 : Adding extra condition before adding jurisdiction to a userProfile

Updated test cases

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
