### PR TITLE
CCD-2108: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -179,7 +179,7 @@ dependencyManagement {
     }
     dependencies {
         // CVE-2019-0232 - Java and Command Line injections in Windows
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.50') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.54') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -12,9 +12,4 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-	<suppress until="2021-11-25">
-		<notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-		<cve>CVE-2021-42340</cve>
-	</suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2108 (https://tools.hmcts.net/jira/browse/CCD-2108)


### Change description ###
- Updated dependencyManagement section of build.gradle. Set version of org.apache.tomcat.embed group to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from dependency-check-suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
