### PR TITLE
CCD-2142: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ ext {
 
 ext['junit-jupiter.version'] = '5.7.0'
 ext['junit-vintage.version'] = '5.7.0'
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 
 dependencies {
     compile('org.projectlombok:lombok:1.18.6')

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -12,9 +12,4 @@
 		<cve>CVE-2018-1258</cve>
 	</suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Temp suppression to unblock pipeline.</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
-
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions
-	xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
 	<!-- THIS WILL BE FIXED IN THE USER PROFILE SPRING CVEs TICKET -->
 	<suppress until="2021-11-25">


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2142 (https://tools.hmcts.net/jira/browse/CCD-2142)


### Change description ###
- Updated build.gradle. Set value of override of spring-framework.version property to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from dependency-check-suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
