### PR TITLE
CCD-2378: Re-enable Fortify scan

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -35,12 +35,11 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withNightlyPipeline(type, product, component) {
     loadVaultSecrets(secrets)
     enableMutationTest()
-    // Temporarily disable fortify scan stage until fortify access re-enabled
-    //enableFortifyScan()
+    enableFortifyScan()
     enableDbMigration('ccd')
     enableSlackNotifications('#ccd-nightly-builds')
     enableHighLevelDataSetup()
-    //after('fortify-scan') {
-    //    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
-    //}
+    after('fortify-scan') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -338,6 +338,7 @@ task fortifyScan(type: JavaExec)  {
     main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
     classpath += sourceSets.test.runtimeClasspath
     jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
+    ignoreExitValue = true
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -338,7 +338,8 @@ task fortifyScan(type: JavaExec)  {
     main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
     classpath += sourceSets.test.runtimeClasspath
     jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
-    ignoreExitValue = true
+    // Uncomment the line below to prevent the build from failing if the Fortify scan detects issues
+    //ignoreExitValue = true
 }
 
 

--- a/config/fortify-client.properties
+++ b/config/fortify-client.properties
@@ -1,2 +1,1 @@
-fortify.client.releaseId=65430
-
+fortify.client.releaseId=91365


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2378 (https://tools.hmcts.net/jira/browse/CCD-2378)


### Change description ###
- Changed fortify release id in fortify-client.properties to new value provided by fortify support.  This should resolve the "The entitlementPreferenceType is not available" error in the Fortify Scan stage of the nightly build pipeline.
- Uncommented Fortify scan steps in Jenkinsfile_nightly to re-enable Fortify scan


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
