### PR TITLE
CCD-3109 Updated spring-framework.version to 5.3.19 and removed suppression for CVE-2022-22968

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ ext {
 
 ext['junit-jupiter.version'] = '5.7.0'
 ext['junit-vintage.version'] = '5.7.0'
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 ext['log4j2.version'] = '2.17.0'
 ext['jackson.version'] = '2.13.2'
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -32,14 +32,6 @@
 
 	<suppress until="2022-05-25">
 		<notes><![CDATA[
-   file name: spring-core-5.3.18.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-		<cve>CVE-2022-22968</cve>
-	</suppress>
-
-	<suppress until="2022-05-25">
-		<notes><![CDATA[
    file name: spring-security-config-5.6.1.jar
    ]]></notes>
 		<packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-config@.*$</packageUrl>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3109

### Change description ###

Updated spring-framework.version to 5.3.19 and removed suppression for CVE-2022-22968


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
