### PR TITLE
CCD-3088 Remove redundant entries from suppression files

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -13,14 +13,6 @@
 
 	<suppress until="2022-06-25">
 		<notes><![CDATA[
-   file name: jackson-databind-2.11.0.rc1.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-		<cve>CVE-2020-36518</cve>
-	</suppress>
-
-	<suppress until="2022-06-25">
-		<notes><![CDATA[
    file name: postgresql-42.2.16.jar
    ]]></notes>
 		<packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
@@ -58,14 +50,14 @@
 		<packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-web@.*$</packageUrl>
 		<cve>CVE-2018-1258</cve>
 	</suppress>
-  
+
 	<suppress until="2022-06-25">
 		<notes><![CDATA[
    file name: spring-core-5.3.18.jar
    ]]></notes>
     <cve>CVE-2022-22970</cve>
 	</suppress>
-	
+
   <suppress until="2022-06-25">
 		<notes><![CDATA[
    file name: spring-core-5.3.19.jar


### PR DESCRIPTION
CCD-3088 Remove redundant entries from suppression files - CVE-2020-36518 removed
https://tools.hmcts.net/jira/browse/CCD-3088

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
