### PR TITLE
CVE-2022-29885: ccd-user-profile-api fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencyManagement {
     }
     dependencies {
         // CVE-2022-23181
-        dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.0-M15') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencyManagement {
     }
     dependencies {
         // CVE-2022-23181
-        dependencySet(group: 'org.apache.tomcat.embed', version: '10.0.21') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.0-M15') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencyManagement {
     }
     dependencies {
         // CVE-2022-23181
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.58') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '10.0.21') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -64,23 +64,4 @@
    ]]></notes>
 		<cve>CVE-2016-1000027</cve>
 	</suppress>
-
-
-	<suppress until="2022-06-25">
-		<notes><![CDATA[
-   file name: tomcat-embed-core-9.0.58.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-		<cve>CVE-2022-29885</cve>
-	</suppress>
-
-
-	<suppress until="2022-06-25">
-		<notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.58.jar
-   ]]></notes>
-		<packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-		<cve>CVE-2022-29885</cve>
-	</suppress>
-
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3264

Upgrading tomcat version to 10.0.21.
The documentation of Apache Tomcat 10.1.0-M1 to 10.1.0-M14, 10.0.0-M1 to 10.0.20, 9.0.13 to 9.0.62 and 8.5.38 to 8.5.78 for the EncryptInterceptor incorrectly stated it enabled Tomcat clustering to run over an untrusted network. This was not correct. While the EncryptInterceptor does provide confidentiality and integrity protection, it does not protect against all risks associated with running over any untrusted network, particularly DoS risks.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
