### PR TITLE
CCD-3297: Added junit formatter to smoke and functional test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -370,8 +370,10 @@ task smoke() {
     javaexec {
       main = "uk.gov.hmcts.ccd.userprofile.befta.UserProfileBeftaMain"
       classpath += configurations.cucumberRuntime + sourceSets.aat.runtimeClasspath
-      args = ['--plugin', "json:${rootDir}/target/cucumber.json", '--tags', '@Smoke', '--glue',
-              'uk.gov.hmcts.befta.player', 'src/aat/resources/features']
+      args = ['--plugin', "json:${rootDir}/target/cucumber.json",
+              '--plugin', "junit:${buildDir}/test-results/smoke/cucumber.xml",
+              '--tags', '@Smoke',
+              '--glue', 'uk.gov.hmcts.befta.player', 'src/aat/resources/features']
       jvmArgs = [ '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED' ]
     }
   }
@@ -402,8 +404,10 @@ task functional() {
     javaexec {
       main = "uk.gov.hmcts.ccd.userprofile.befta.UserProfileBeftaMain"
       classpath += configurations.cucumberRuntime + sourceSets.aat.runtimeClasspath + sourceSets.main.output + sourceSets.test.output
-      args = ['--plugin', "json:${rootDir}/target/cucumber.json", '--tags', 'not @Ignore', '--glue',
-              'uk.gov.hmcts.befta.player', 'src/aat/resources/features']
+      args = ['--plugin', "json:${rootDir}/target/cucumber.json",
+              '--plugin', "junit:${buildDir}/test-results/functional/cucumber.xml",
+              '--tags', 'not @Ignore',
+              '--glue', 'uk.gov.hmcts.befta.player', 'src/aat/resources/features']
       jvmArgs = [ '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED' ]
     }
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3297 (https://tools.hmcts.net/jira/browse/CCD-3297)


### Change description ###
Added junit formatter plugin to doLast section of smoke and functional test tasks.  This causes test result XML files to be created in the locations expected by the smoke and functional stages of the pipeline.  These locations were recently corrected under DTSPO-6817.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
