### PR TITLE
CCD-3432 CVE-2022-34305 suppression moved from temp to false positive

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -6,22 +6,22 @@
 		<notes>False Positives
 			CVE-2018-1258 https://tools.hmcts.net/jira/browse/CCD-496
 			CVE-2016-1000027 https://tools.hmcts.net/jira/browse/CCD-3257
+			CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3432
 		</notes>
 		<cve>CVE-2018-1258</cve>
 		<cve>CVE-2016-1000027</cve>
+		<cve>CVE-2022-34305</cve>
 	</suppress>
 	<!--End of false positives section -->
 
 	<!--Please add all the temporary suppression under the below section -->
   	<suppress>
     		<notes>Temporary Suppression
-      			CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3432
       			CVE-2022-31569  refer https://tools.hmcts.net/jira/browse/CCD-3536
-            CVE-2022-22978  refer https://tools.hmcts.net/jira/browse/CCD-3513
+            	CVE-2022-22978  refer https://tools.hmcts.net/jira/browse/CCD-3513
     		</notes>
-    		<cve>CVE-2022-34305</cve>
     		<cve>CVE-2022-31569</cve>
-        <cve>CVE-2022-22978</cve>
+		<cve>CVE-2022-22978</cve>
   	</suppress>
   	<!--End of temporary suppression section -->
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3432
CVE-2022-34305 suppression moved from temp to False Positive 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
