### PR TITLE
CCD-3606: Temporarily suppress CVE-2022-31197

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -14,14 +14,16 @@
 
 	<!--Please add all the temporary suppression under the below section -->
   	<suppress>
-    		<notes>Temporary Suppression
-      			CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3432
-      			CVE-2022-31569  refer https://tools.hmcts.net/jira/browse/CCD-3536
-            CVE-2022-22978  refer https://tools.hmcts.net/jira/browse/CCD-3513
-    		</notes>
-    		<cve>CVE-2022-34305</cve>
-    		<cve>CVE-2022-31569</cve>
-        <cve>CVE-2022-22978</cve>
+		<notes>Temporary Suppression
+			CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3432
+			CVE-2022-31569  refer https://tools.hmcts.net/jira/browse/CCD-3536
+			CVE-2022-22978  refer https://tools.hmcts.net/jira/browse/CCD-3513
+			CVE-2022-31197  refer https://tools.hmcts.net/jira/browse/CCD-3606
+		</notes>
+		<cve>CVE-2022-34305</cve>
+		<cve>CVE-2022-31569</cve>
+		<cve>CVE-2022-22978</cve>
+		<cve>CVE-2022-31197</cve>
   	</suppress>
   	<!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3606 (https://tools.hmcts.net/jira/browse/CCD-3606)


### Change description ###
Updated suppressions file to temporarily suppress CVE-2022-31197.  Also tied up indentation of temporary suppressions section.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
