### PR TITLE
CCD-3606: CVE-2022-31197 - Upgraded org.postgresql to 42.4.1 and removed temp suppression

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.13.2'
     compile group: 'org.yaml', name: 'snakeyaml', version: '1.26'
     compile group: 'com.zaxxer', name: 'HikariCP', version: '4.0.2'
-    runtime group: 'org.postgresql', name: 'postgresql', version: '42.3.5'
+    runtime group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
     compile group: 'javax.inject', name: 'javax.inject', version: '1'
     compile (group: 'com.github.hmcts', name: 'auth-checker-lib', version: '2.1.5') {
         // TODO remove when auth-checker-lib upgrades its dependency to spring boot 2.0.x

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -18,12 +18,10 @@
 			CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3432
 			CVE-2022-31569  refer https://tools.hmcts.net/jira/browse/CCD-3536
 			CVE-2022-22978  refer https://tools.hmcts.net/jira/browse/CCD-3513
-			CVE-2022-31197  refer https://tools.hmcts.net/jira/browse/CCD-3606
 		</notes>
 		<cve>CVE-2022-34305</cve>
 		<cve>CVE-2022-31569</cve>
 		<cve>CVE-2022-22978</cve>
-		<cve>CVE-2022-31197</cve>
   	</suppress>
   	<!--End of temporary suppression section -->
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3606

### Change description ###

CCD-3606: CVE-2022-31197 - Upgraded org.postgresql to 42.4.1 and removed temp suppression

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
