### PR TITLE
CCD-3432 CVE-2022-34305 tomcat upgrade 9.0.65, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencyManagement {
     }
     dependencies {
         // CVE-2022-23181
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.65') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -5,10 +5,8 @@
 	<suppress>
 		<notes>False Positives
 			CVE-2016-1000027 https://tools.hmcts.net/jira/browse/CCD-3257
-			CVE-2022-34305  refer https://tools.hmcts.net/jira/browse/CCD-3432
 		</notes>
 		<cve>CVE-2016-1000027</cve>
-		<cve>CVE-2022-34305</cve>
 	</suppress>
 	<!--End of false positives section -->
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3432
CVE-2022-34305 tomcat upgrade 9.0.65

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
