### PR TITLE
CCD-3694 CCD-3836  run existing FTAs against next test definition release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ dependencies {
     compile group: 'org.springframework.security', name: 'spring-security-web', version: '5.6.6'
     compile group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.6.6'
 
-    compile 'uk.gov.hmcts.reform:properties-volume-spring-boot-starter:0.0.4'
+    compile 'com.github.hmcts:properties-volume-spring-boot-starter:0.0.4'
 
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: versions.jackson
@@ -352,6 +352,13 @@ task fortifyScan(type: JavaExec)  {
     ignoreExitValue = true
 }
 
+idea {
+  module {
+    // config to allow Intelij to mark test source and resource files correctly to help linting tools
+    testSourceDirs += project.sourceSets.aat.java.srcDirs
+    testResourceDirs += project.sourceSets.aat.resources.srcDirs
+  }
+}
 
 task highLevelDataSetup(type: JavaExec) {
     dependsOn aatClasses
@@ -387,8 +394,10 @@ task smoke() {
   finalizedBy {
     generateCucumberReports {
       doLast{
+        delete "${rootDir}/BEFTA Report for Smoke Tests/"
         new File("${rootDir}/BEFTA Report for Smoke Tests").mkdirs()
         file("${rootDir}/target/cucumber/cucumber-html-reports").renameTo(file("${rootDir}/BEFTA Report for Smoke Tests"))
+        logger.quiet("Smoke test report moved to ---> file://${rootDir}/BEFTA%20Report%20for%20Smoke%20Tests/overview-features.html")
       }
     }
   }
@@ -421,8 +430,10 @@ task functional() {
   finalizedBy {
     generateCucumberReports {
       doLast{
+        delete "${rootDir}/BEFTA Report for Functional Tests/"
         new File("${rootDir}/BEFTA Report for Functional Tests").mkdirs()
         file("${rootDir}/target/cucumber/cucumber-html-reports").renameTo(file("${rootDir}/BEFTA Report for Functional Tests"))
+        logger.quiet("Functional test report moved to ---> file://${rootDir}/BEFTA%20Report%20for%20Functional%20Tests/overview-features.html")
       }
     }
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [CCD-3675](https://tools.hmcts.net/jira/browse/CCD-3675) _"Global Search - Access Process should take into account mapped access profiles"_
   [CCD-3694](https://tools.hmcts.net/jira/browse/CCD-3694) _"FTAs for Global Search - Access Process CCD-3675"_

   [CCD-3798](https://tools.hmcts.net/jira/browse/CCD-3798) _"ACCESS_GRANTED metadata needs to consider role assignments giving access to cases"_
   [CCD-3836](https://tools.hmcts.net/jira/browse/CCD-3836) _"FTAs for ACCESS_GRANTED metadata changes CCD-3798"_

### Change description ###

Run existing FTAs against the next `befta-fw` & `ccd-test-definitions` release, see: hmcts/befta-fw#192 and hmcts/ccd-test-definitions#57.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
