### PR TITLE
CCD-4157 CVE-2022-3064 CVE-2021-4235 moved to false positive

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>False Positives
+            CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
+            CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157</notes>
+        <cve>CVE-2022-3064</cve>
+        <cve>CVE-2021-4235</cve>
+    </suppress>
   <suppress>
     <notes>Temporary Suppression
         CVE-2021-37533 refer [Ticket]
         CVE-2021-4277 refer [Ticket]
-        CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
-        CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157
         CVE-2022-45143 refer [Ticket]</notes>
     <cve>CVE-2021-37533</cve>
     <cve>CVE-2021-4277</cve>
-    <cve>CVE-2022-3064</cve>
-    <cve>CVE-2021-4235</cve>
     <cve>CVE-2022-45143</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4157
CVE-2022-3064 CVE-2021-4235 moved to false positive

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
