### PR TITLE
CCD-4233 CVE-2022-45143 Upgrade Tomcat to 9.0.69, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ dependencyManagement {
     }
     dependencies {
         // CVE-2022-23181
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.69') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2021-37533 refer [Ticket]
-        CVE-2021-4277 refer [Ticket]
+        CVE-2021-4277 refer https://tools.hmcts.net/jira/browse/CCD-4148
         CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
         CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157</notes>
     <cve>CVE-2021-4277</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -4,11 +4,9 @@
         CVE-2021-37533 refer [Ticket]
         CVE-2021-4277 refer [Ticket]
         CVE-2022-3064 refer https://tools.hmcts.net/jira/browse/CCD-4157
-        CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157
-        CVE-2022-45143 refer [Ticket]</notes>
+        CVE-2021-4235 refer https://tools.hmcts.net/jira/browse/CCD-4157</notes>
     <cve>CVE-2021-4277</cve>
     <cve>CVE-2022-3064</cve>
     <cve>CVE-2021-4235</cve>
-    <cve>CVE-2022-45143</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4233
CVE-2022-45143 Upgrade Tomcat to 9.0.69, suppression removed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
