### PR TITLE
CCD-4398 Upgrade dependencies to resolve CVE-2023-24998

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,6 +144,7 @@ dependencies {
     compile group: 'javax.inject', name: 'javax.inject', version: '1'
     compile group: 'com.github.hmcts', name: 'auth-checker-lib', version: '2.1.5'
 
+    implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
     compile group: 'com.sun.mail', name: 'mailapi', version: '1.6.1'
@@ -184,7 +185,7 @@ dependencyManagement {
     }
     dependencies {
         // CVE-2022-23181
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.69') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.73') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/charts/ccd-user-profile-api/Chart.yaml
+++ b/charts/ccd-user-profile-api/Chart.yaml
@@ -2,7 +2,7 @@ description: CCD User profile
 name: ccd-user-profile-api
 apiVersion: v2
 home: https://github.com/hmcts/ccd-user-profile-api
-version: 1.6.9
+version: 1.6.10
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-user-profile-api/Chart.yaml
+++ b/charts/ccd-user-profile-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
     email: ccd-devops@HMCTS.NET
 dependencies:
   - name: java
-    version: 4.0.12
+    version: 4.0.13
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4398


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
