### PR TITLE
CCD-4739 : Fix CVE-2023-20863 (bump version of springframework)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ ext {
 
 ext['junit-jupiter.version'] = '5.7.0'
 ext['junit-vintage.version'] = '5.7.0'
-ext['spring-framework.version'] = '5.3.26'
+ext['spring-framework.version'] = '5.3.27'
 ext['log4j2.version'] = '2.17.0'
 ext['jackson.version'] = '2.14.1'
 ext['snakeyaml.version'] = '1.32'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -3,12 +3,11 @@
     <notes>Temporary Suppression
         CVE-2022-45688 refer [Ticket]
         CVE-2022-1471 refer [Ticket]
-        CVE-2023-20863 refer [Ticket]
         CVE-2023-28709 refer [Ticket]
-        CVE-2023-20883 refer [Ticket]</notes>
+        CVE-2023-20883 refer [Ticket]
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2023-20863</cve>
     <cve>CVE-2023-28709</cve>
     <cve>CVE-2023-20883</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4739

### Change description ###

CCD-4739 : Fix CVE-2023-20863 (bump version of springframework)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
