### PR TITLE
CCD-4845: renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>hmcts/.github//renovate/global"],
+  "extends": ["local>hmcts/.github:renovate-config"],
   "labels": ["Renovate-dependencies"],
   "major": {
     "dependencyDashboardApproval": true

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -69,11 +69,6 @@ withPipeline(type, product, component) {
     }
     onPR {
         enableSlackNotifications('#ccd-pr-builds')
-
-        def githubApi = new GithubAPI(this)
-        if (!githubApi.getLabelsbyPattern(env.BRANCH_NAME, "keep-helm")) {
-            enableCleanupOfHelmReleaseAlways()
-        }
     }
 
     // Check if the build should be wired to a preview instance of definition store


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4845

### Change description ###
Renovate config is now mandatory in every repo extending default org level config without using enabledManagers.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
