### PR TITLE
CCD-4970 : Fix CVE-2020-8908  

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -7,6 +7,7 @@
         CVE-2023-42795 refer [Ticket]
         CVE-2023-45648 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
+        CVE-2020-8908 refer [Ticket]
     </notes>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-2976</cve>
@@ -14,5 +15,6 @@
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>
     <cve>CVE-2023-44487</cve>
+    <cve>CVE-2020-8908</cve>
   </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -3,7 +3,6 @@
     <notes>Temporary Suppression
         CVE-2023-35116 refer [Ticket]
         CVE-2023-2976 refer [Ticket]
-        CVE-2020-8908 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
         CVE-2023-45648 refer [Ticket]
@@ -11,7 +10,6 @@
     </notes>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-2976</cve>
-    <cve>CVE-2020-8908</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-4970

### Change description ###

removed suppression, no useage of Gauva detected

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
