### PR TITLE
CCD-5160 : Fix CVE-2023-35116 : bumped jackson.version to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ ext {
 ext['junit-jupiter.version'] = '5.10.0'
 ext['junit-vintage.version'] = '5.10.0'
 ext['spring-framework.version'] = '6.0.11'
-ext['jackson.version'] = '2.15.3'
+ext['jackson.version'] = '2.16.0'
 ext['snakeyaml.version'] = '2.1'
 
 dependencyManagement {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2023-2976 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
         CVE-2023-45648 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
-        CVE-2020-8908 refer [Ticket]
-
         CVE-2023-34053 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]
+        CVE-2022-45868 refer [Ticket]
+        CVE-2023-33202 refer [Ticket]
         CVE-2024-23686 refer [Ticket]
         CVE-2023-34042 refer [Ticket]
         CVE-2024-25710 refer [Ticket]
-        CVE-2024-26308 refer [Ticket]</notes>
+        CVE-2024-26308 refer [Ticket]
+    </notes>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>
@@ -23,7 +22,6 @@
     <cve>CVE-2023-34053</cve>
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-35116</cve>
     <cve>CVE-2022-45868</cve>
     <cve>CVE-2023-33202</cve>
     <cve>CVE-2024-23686</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-5160
CCD-5160 : Fix CVE-2023-35116 : bumped jackson.version to 2.16.0


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
