### PR TITLE
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 10.1.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,13 @@ dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
+    dependencies {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.13') {
+            entry 'tomcat-embed-core'
+            entry 'tomcat-embed-el'
+            entry 'tomcat-embed-websocket'
+        }
+    }
 }
 
 dependencies {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,34 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2023-2976 refer [Ticket]
-        CVE-2023-41080 refer [Ticket]
-        CVE-2023-42795 refer [Ticket]
-        CVE-2023-45648 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]
-        CVE-2020-8908 refer [Ticket]
-
+        CVE-2023-33202 refer [Ticket]
+        CVE-2024-25710 refer [Ticket]
+        CVE-2024-26308 refer [Ticket]
+        CVE-2024-23686 refer [Ticket]
+        CVE-2022-45868 refer [Ticket]
+        CVE-2023-35116 refer [Ticket]
         CVE-2023-34053 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
-        CVE-2023-46589 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]
-        CVE-2024-23686 refer [Ticket]
         CVE-2023-34042 refer [Ticket]
-        CVE-2024-25710 refer [Ticket]
-        CVE-2024-26308 refer [Ticket]</notes>
-    <cve>CVE-2023-41080</cve>
-    <cve>CVE-2023-42795</cve>
-    <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-34053</cve>
-    <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-35116</cve>
-    <cve>CVE-2022-45868</cve>
+        CVE-2023-44487 refer [Ticket]
+        CVE-2023-46589 refer [Ticket]
+        CVE-2023-42795 refer [Ticket]
+        CVE-2023-45648 refer [Ticket]</notes>
     <cve>CVE-2023-33202</cve>
-    <cve>CVE-2024-23686</cve>
-    <cve>CVE-2023-34042</cve>
     <cve>CVE-2024-25710</cve>
     <cve>CVE-2024-26308</cve>
+    <cve>CVE-2024-23686</cve>
+    <cve>CVE-2022-45868</cve>
+    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-34053</cve>
+    <cve>CVE-2023-34055</cve>
+    <cve>CVE-2023-34042</cve>
+    <cve>CVE-2023-44487</cve>
+    <cve>CVE-2023-46589</cve>
+    <cve>CVE-2023-42795</cve>
+    <cve>CVE-2023-45648</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4972
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 10.1.13

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
