### PR TITLE
CVE-2023-33202 : Fix org.bouncycastle vulnerable version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,7 @@ dependencies {
 
     // dependency check
     implementation group: 'org.owasp', name: 'dependency-check-gradle', version: '9.0.4'
+    implementation group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: '1.73'
 
     // CVE-2021-28170
     implementation "org.glassfish:jakarta.el:4.0.2"

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -7,7 +7,6 @@
         CVE-2023-45648 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2020-8908 refer [Ticket]
-
         CVE-2023-34053 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
@@ -15,7 +14,8 @@
         CVE-2024-23686 refer [Ticket]
         CVE-2023-34042 refer [Ticket]
         CVE-2024-25710 refer [Ticket]
-        CVE-2024-26308 refer [Ticket]</notes>
+        CVE-2024-26308 refer [Ticket]
+    </notes>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>
@@ -25,7 +25,6 @@
     <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2022-45868</cve>
-    <cve>CVE-2023-33202</cve>
     <cve>CVE-2024-23686</cve>
     <cve>CVE-2023-34042</cve>
     <cve>CVE-2024-25710</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-5076
CVE-2023-33202 : Fix org.bouncycastle vulnerable version



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
