### PR TITLE
CCD-5201 Upgraded spring security to 6.1.5 as this is the last version that do…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ ext {
     lombokVersion = '1.18.28'
     reformLogging = '6.0.1'
     springCloudVersion = '2022.0.3'
-    springSecurity = '6.1.2'
+    springSecurity = '6.1.5'
     limits = [
             'instruction': 6,
             'branch'     : 8,

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -9,7 +9,6 @@
         CVE-2023-35116 refer [Ticket]
         CVE-2023-34053 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
-        CVE-2023-34042 refer [Ticket]
         CVE-2023-44487 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
@@ -22,7 +21,6 @@
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-34053</cve>
     <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-34042</cve>
     <cve>CVE-2023-44487</cve>
     <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-42795</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-5201


### Change description ###
Upgraded spring security to 6.1.5 as this is the last version that doesn't cause tests to fail.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
