### PR TITLE
Bump java chart due to pipeline failures

### DIFF
--- a/charts/ccd-user-profile-api/Chart.yaml
+++ b/charts/ccd-user-profile-api/Chart.yaml
@@ -2,7 +2,7 @@ description: CCD User profile
 name: ccd-user-profile-api
 apiVersion: v2
 home: https://github.com/hmcts/ccd-user-profile-api
-version: 1.6.12
+version: 1.6.13
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-user-profile-api/Chart.yaml
+++ b/charts/ccd-user-profile-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
     email: ccd-devops@HMCTS.NET
 dependencies:
   - name: java
-    version: 5.0.0
+    version: 5.2.0
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'


### PR DESCRIPTION


### Change description ###
Current failures in pipelines due to java chart requiring an update from 5.0.0 to 5.2.0 

 + echo ' chart 5.0.0 is deprecated, please upgrade to at least 5.2.0'
  chart 5.0.0 is deprecated, please upgrade to at least 5.2.0
 + exit 1

https://build.hmcts.net/view/CDM%20DEV/job/HMCTS_a_to_c/job/ccd-user-profile-api/job/PR-399/544/execution/node/238/log/

