### PR TITLE
Remove unnecessary runtime dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,11 @@ dependencies {
     implementation group: 'com.zaxxer', name: 'HikariCP', version: '5.0.1'
     runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.6.0'
     implementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: '2.1.5'
+    constraints {
+        implementation('com.google.guava:guava:33.1.0-jre') {
+            because 'previous versions of this transitive dependency have CVEs'
+        }
+    }
     implementation group: 'javax.inject', name: 'javax.inject', version: '1'
 
     implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'

--- a/build.gradle
+++ b/build.gradle
@@ -173,9 +173,6 @@ dependencies {
     implementation group: 'org.springframework.security', name: 'spring-security-web', version: springSecurity
     implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: springSecurity
 
-    // CVE-2021-28170
-    implementation "org.glassfish:jakarta.el:4.0.2"
-
     aatImplementation 'com.github.hmcts:service-auth-provider-java-client:5.1.0'
     codacy 'com.github.codacy:codacy-coverage-reporter:13.13.7'
     testImplementation "org.junit.jupiter:junit-jupiter-api"

--- a/build.gradle
+++ b/build.gradle
@@ -173,15 +173,6 @@ dependencies {
     implementation group: 'org.springframework.security', name: 'spring-security-web', version: springSecurity
     implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: springSecurity
 
-    // dependency check
-    implementation 'org.owasp:dependency-check-gradle'
-    constraints {
-        implementation('org.owasp:dependency-check-gradle:9.0.9') {
-        }
-        implementation('org.owasp:dependency-check-core:9.0.9') {
-        }
-    }
-
     // CVE-2021-28170
     implementation "org.glassfish:jakarta.el:4.0.2"
 

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation group: 'org.projectlombok', name: 'lombok', version: lombokVersion
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: lombokVersion
     annotationProcessor  group: 'org.projectlombok', name: 'lombok', version: lombokVersion
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLogging
     implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLogging


### PR DESCRIPTION
Lombok and the owasp dependency checker are build tools that should not form part of the deployed application.