### PR TITLE
CCD-4974:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ dependencyManagement {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
     }
     dependencies {
-        dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.13') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '10.1.29') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,12 +2,10 @@
   <suppress>
     <notes>Temporary Suppression
         CVE-2023-34055 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
         CVE-2023-45648 refer [Ticket]</notes>
     <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-44487</cve>
     <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4974


### Change description ###
Fix CVE-2023-44487, upgraded tomcat-embed-core and tomcat-embed-websocket from 10.1.13 to 10.1.29


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
